### PR TITLE
Remove duplicate imports

### DIFF
--- a/GoogleChrome/QSGoogleChromeBookmarksParser.h
+++ b/GoogleChrome/QSGoogleChromeBookmarksParser.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <QSCore/QSCore.h>
 #import "JSONKit.h"
 #import "QSGoogleChromeDefinitions.h"
 

--- a/GoogleChrome/QSGoogleChromeDatabaseManager.h
+++ b/GoogleChrome/QSGoogleChromeDatabaseManager.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
 #import "QSGoogleChromeDefinitions.h"
 #import "FMDatabase.h"
 #import "FMResultSet.h"

--- a/GoogleChrome/QSGoogleChromeHistoryParser.h
+++ b/GoogleChrome/QSGoogleChromeHistoryParser.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
 #import "QSGoogleChromeDefinitions.h"
 #import "QSGoogleChromeDatabaseManager.h"
 

--- a/GoogleChrome/QSGoogleChromeObjectSource.h
+++ b/GoogleChrome/QSGoogleChromeObjectSource.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <QSCore/QSCore.h>
 #import "QSGoogleChromeDefinitions.h"
 #import "QSGoogleChromeBookmarksParser.h"
 #import "QSGoogleChromeHistoryParser.h"

--- a/GoogleChrome/QSGoogleChromeProxies.h
+++ b/GoogleChrome/QSGoogleChromeProxies.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
 #import "QSGoogleChromeDefinitions.h"
 
 @interface QSGoogleChromeProxies : NSObject <QSProxyObjectProvider>

--- a/GoogleChrome/QSGoogleChromeSearchEnginesParser.h
+++ b/GoogleChrome/QSGoogleChromeSearchEnginesParser.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 stdin.se. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
 #import "RegexKitLite.h"
 #import "QSGoogleChromeDefinitions.h"
 #import "QSGoogleChromeDatabaseManager.h"


### PR DESCRIPTION
This bugged me today when I tried to build the plugin.
They're all imported by Quicksilver.pch from the Configuration folder

P.S. I was playing with the plugin to see if you'd worked out how to read the Chrome history cache files?
I know that Chrome stores the text for each page visited somewhere, since you can search for any text on a page in the history view (⌘Y).
But it bugs me that I can't actually see the text - for offline browsing. I want to try and find the original content and make it viewable :)
